### PR TITLE
Add README section for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,16 @@ gpu-monitor/
 ├── parser.py             # nvidia-smi出力パース
 ├── notion_client.py      # Notion API操作
 ├── .env                  # 認証情報
+├── tests/                # テストコード
 └── requirements.txt      # 必要パッケージ
+```
+
+## 🧪 テスト
+
+本リポジトリには `pytest` を用いたユニットテストが含まれています。以下のコマンドで実行できます。
+
+```bash
+pytest -q
 ```
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+paramiko
+requests
+python-dotenv
+pytest

--- a/ssh_utils.py
+++ b/ssh_utils.py
@@ -1,0 +1,35 @@
+import paramiko
+
+
+def run_ssh_command(host: str, command: str) -> str:
+    """Execute a command on a remote host via SSH and return its output.
+
+    Parameters
+    ----------
+    host : str
+        Remote host name or IP address.
+    command : str
+        Command to run on the remote host.
+
+    Returns
+    -------
+    str
+        Combined stdout and stderr output from the command.
+    """
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        client.connect(
+            hostname=host,
+            timeout=5,
+            allow_agent=True,
+            look_for_keys=True,
+        )
+        _, stdout, stderr = client.exec_command(command)
+        out = stdout.read().decode()
+        err = stderr.read().decode()
+        return out + err
+    finally:
+        client.close()

--- a/tests/test_ssh_utils.py
+++ b/tests/test_ssh_utils.py
@@ -1,0 +1,44 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import types
+from unittest import mock
+
+# create a minimal paramiko stub if paramiko is missing
+if 'paramiko' not in sys.modules:
+    paramiko_stub = types.ModuleType('paramiko')
+    class AutoAddPolicy:  # noqa: D401
+        """Placeholder policy class."""
+        pass
+    class SSHClient:
+        pass
+    paramiko_stub.AutoAddPolicy = AutoAddPolicy
+    paramiko_stub.SSHClient = SSHClient
+    sys.modules['paramiko'] = paramiko_stub
+
+import paramiko
+
+from ssh_utils import run_ssh_command
+
+
+def test_run_ssh_command_success():
+    mock_client = mock.MagicMock()
+    stdout_mock = mock.MagicMock()
+    stdout_mock.read.return_value = b"out"
+    stderr_mock = mock.MagicMock()
+    stderr_mock.read.return_value = b"err"
+    mock_client.exec_command.return_value = (None, stdout_mock, stderr_mock)
+
+    with mock.patch.object(paramiko, "SSHClient", return_value=mock_client):
+        result = run_ssh_command("example.com", "echo test")
+
+    assert result == "outerr"
+    mock_client.connect.assert_called_once_with(
+        hostname="example.com",
+        timeout=5,
+        allow_agent=True,
+        look_for_keys=True,
+    )
+    mock_client.load_system_host_keys.assert_called_once()
+    mock_client.set_missing_host_key_policy.assert_called_once()
+    mock_client.close.assert_called_once()


### PR DESCRIPTION
## Summary
- document how to run pytest
- add tests folder to directory tree in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d0ec922188321b94172a2939bc0b7