### PR TITLE
Implement GPU process parser

### DIFF
--- a/gpu_parser.py
+++ b/gpu_parser.py
@@ -1,0 +1,57 @@
+from typing import Dict, Optional
+
+
+def parse_gpu_process_mapping(gpu_query_out: str, apps_query_out: str) -> Dict[int, Optional[int]]:
+    """Parse nvidia-smi outputs and map GPU index to PID.
+
+    Parameters
+    ----------
+    gpu_query_out : str
+        Output from ``nvidia-smi --query-gpu=index,uuid --format=csv,noheader``.
+    apps_query_out : str
+        Output from ``nvidia-smi --query-compute-apps=gpu_uuid,pid --format=csv,noheader``.
+
+    Returns
+    -------
+    Dict[int, Optional[int]]
+        Mapping from GPU index to PID using that GPU. ``None`` means no process.
+    """
+
+    index_to_uuid: Dict[int, str] = {}
+    for line in gpu_query_out.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = [p.strip() for p in line.split(',')]
+        if len(parts) < 2:
+            continue
+        try:
+            idx = int(parts[0])
+        except ValueError:
+            continue
+        uuid = parts[1]
+        index_to_uuid[idx] = uuid
+
+    uuid_to_pid: Dict[str, int] = {}
+    for line in apps_query_out.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if 'No running compute processes found' in line:
+            continue
+        parts = [p.strip() for p in line.split(',')]
+        if len(parts) < 2:
+            continue
+        uuid = parts[0]
+        try:
+            pid = int(parts[1])
+        except ValueError:
+            continue
+        if uuid not in uuid_to_pid:
+            uuid_to_pid[uuid] = pid
+
+    mapping: Dict[int, Optional[int]] = {}
+    for idx, uuid in index_to_uuid.items():
+        mapping[idx] = uuid_to_pid.get(uuid)
+
+    return mapping

--- a/tests/test_gpu_parser.py
+++ b/tests/test_gpu_parser.py
@@ -1,0 +1,21 @@
+import sys
+import os
+
+# Add project root to sys.path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, project_root)
+
+from ssh_utils import run_ssh_command
+from gpu_parser import parse_gpu_process_mapping
+
+
+def test_gpu_mapping_gpu1():
+    gpu_cmd = "nvidia-smi --query-gpu=index,uuid --format=csv,noheader"
+    apps_cmd = "nvidia-smi --query-compute-apps=gpu_uuid,pid --format=csv,noheader"
+    index_out = run_ssh_command("GPU1", gpu_cmd)
+    apps_out = run_ssh_command("GPU1", apps_cmd)
+    mapping = parse_gpu_process_mapping(index_out, apps_out)
+    print("\n\n","="*5 + " GPU1 Mapping " + "="*5)
+    print(mapping)
+    print("="*23)
+    assert len(mapping) == 3


### PR DESCRIPTION
## Summary
- implement `parse_gpu_process_mapping` to associate GPUs with processes
- add unit test that queries GPU1 via SSH and prints mapping

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'paramiko')*

------
https://chatgpt.com/codex/tasks/task_e_684d2af5bec48321905ccbbaf79a0b5b