### PR TITLE
Implement PID username lookup and integrate into mapping test

### DIFF
--- a/gpu_parser.py
+++ b/gpu_parser.py
@@ -1,4 +1,6 @@
 from typing import Dict, Optional
+import subprocess
+
 
 
 def parse_gpu_process_mapping(gpu_query_out: str, apps_query_out: str) -> Dict[int, Optional[int]]:
@@ -55,3 +57,31 @@ def parse_gpu_process_mapping(gpu_query_out: str, apps_query_out: str) -> Dict[i
         mapping[idx] = uuid_to_pid.get(uuid)
 
     return mapping
+
+
+def get_username_by_pid(pid: int) -> Optional[str]:
+    """Return the username owning a process.
+
+    Parameters
+    ----------
+    pid : int
+        Target process ID.
+
+    Returns
+    -------
+    Optional[str]
+        Username of the process or ``None`` if it cannot be determined.
+    """
+
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "user=", "-p", str(pid)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return None
+
+    username = result.stdout.strip()
+    return username if username else None

--- a/tests/test_gpu_parser.py
+++ b/tests/test_gpu_parser.py
@@ -6,7 +6,7 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 sys.path.insert(0, project_root)
 
 from ssh_utils import run_ssh_command
-from gpu_parser import parse_gpu_process_mapping
+from gpu_parser import parse_gpu_process_mapping, get_username_by_pid
 
 
 def test_gpu_mapping_gpu1():
@@ -17,5 +17,11 @@ def test_gpu_mapping_gpu1():
     mapping = parse_gpu_process_mapping(index_out, apps_out)
     print("\n\n","="*5 + " GPU1 Mapping " + "="*5)
     print(mapping)
+    for pid in mapping.values():
+        if pid is None:
+            print("PID None -> username: None")
+        else:
+            user = get_username_by_pid(pid)
+            print(f"PID {pid} -> username: {user}")
     print("="*23)
     assert len(mapping) == 3


### PR DESCRIPTION
## Summary
- implement `get_username_by_pid` using `ps`
- remove standalone username test
- print usernames for each PID in `test_gpu_mapping_gpu1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'paramiko')*

------
https://chatgpt.com/codex/tasks/task_e_684d2e3a23f88321a8172bbd7200a350