### PR TITLE
feat: reuse ssh connection

### DIFF
--- a/gpu_parser.py
+++ b/gpu_parser.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 import subprocess
 
-from ssh_utils import run_ssh_command
+from ssh_utils import run_ssh_command, SSHSession
 
 def parse_gpu_process_mapping(gpu_query_out: str, apps_query_out: str) -> Dict[int, Optional[int]]:
     """Parse nvidia-smi outputs and map GPU index to PID.
@@ -59,7 +59,7 @@ def parse_gpu_process_mapping(gpu_query_out: str, apps_query_out: str) -> Dict[i
     return mapping
 
 
-def get_username_by_pid(host: str, pid: int) -> Optional[str]:
+def get_username_by_pid(host: str, pid: int, session: SSHSession | None = None) -> Optional[str]:
     """Return the username owning a process.
 
     Parameters
@@ -76,7 +76,10 @@ def get_username_by_pid(host: str, pid: int) -> Optional[str]:
     """
     try:
         cmd = f"ps -o user= -p {pid}"
-        result = run_ssh_command(host, cmd)
+        if session is not None:
+            result = session.run(cmd)
+        else:
+            result = run_ssh_command(host, cmd)
         return result.strip() if result.strip() else None
     except Exception:
         return None

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from ssh_utils import run_ssh_command
+from ssh_utils import SSHSession
 from gpu_parser import parse_gpu_process_mapping, get_username_by_pid
 from time import sleep
 
@@ -10,27 +10,28 @@ def main():
         print(f"\n{'=' * 10} {machine} {'=' * 10}")
         sleep(1)
         try:
-            # 1. GPU index と UUID の対応
-            gpu_cmd = "nvidia-smi --query-gpu=index,uuid --format=csv,noheader"
-            index_output = run_ssh_command(machine, gpu_cmd)
+            with SSHSession(machine) as session:
+                # 1. GPU index と UUID の対応
+                gpu_cmd = "nvidia-smi --query-gpu=index,uuid --format=csv,noheader"
+                index_output = session.run(gpu_cmd)
 
-            # 2. UUID と PID の対応
-            apps_cmd = "nvidia-smi --query-compute-apps=gpu_uuid,pid --format=csv,noheader"
-            apps_output = run_ssh_command(machine, apps_cmd)
+                # 2. UUID と PID の対応
+                apps_cmd = "nvidia-smi --query-compute-apps=gpu_uuid,pid --format=csv,noheader"
+                apps_output = session.run(apps_cmd)
 
-            # 3. GPU index → PID のマッピング
-            mapping = parse_gpu_process_mapping(index_output, apps_output)
+                # 3. GPU index → PID のマッピング
+                mapping = parse_gpu_process_mapping(index_output, apps_output)
 
-            # 4. 各GPUの使用状況とユーザー表示
-            for gpu_index, pid in mapping.items():
-                if pid is None:
-                    print(f"GPU{gpu_index}: 空き")
-                else:
-                    user = get_username_by_pid(machine, pid)
-                    if user:
-                        print(f"GPU{gpu_index}: 使用中 by {user} (PID {pid})")
+                # 4. 各GPUの使用状況とユーザー表示
+                for gpu_index, pid in mapping.items():
+                    if pid is None:
+                        print(f"GPU{gpu_index}: 空き")
                     else:
-                        print(f"GPU{gpu_index}: 使用中（ユーザー不明） (PID {pid})")
+                        user = get_username_by_pid(machine, pid, session=session)
+                        if user:
+                            print(f"GPU{gpu_index}: 使用中 by {user} (PID {pid})")
+                        else:
+                            print(f"GPU{gpu_index}: 使用中（ユーザー不明） (PID {pid})")
 
         except Exception as e:
             print(f"[エラー] {machine} の取得に失敗しました: {e}")

--- a/ssh_utils.py
+++ b/ssh_utils.py
@@ -3,64 +3,75 @@ import paramiko
 from paramiko.proxy import ProxyCommand
 from paramiko.config import SSHConfig
 
-def run_ssh_command(host_alias: str, command: str) -> str:
-    """
-    Execute a command on a remote host via SSH using ~/.ssh/config settings.
+
+class SSHSession:
+    """Maintain a persistent SSH session for running multiple commands.
 
     Parameters
     ----------
     host_alias : str
-        SSH config alias (e.g., "GPU1") or direct hostname/IP.
-    command : str
-        Command to run on the remote host.
-
-    Returns
-    -------
-    str
-        Combined stdout and stderr output from the command.
+        SSH config alias (e.g., ``"GPU1"``) or direct hostname/IP.
     """
-    # Parse the user's SSH config file
-    ssh_config = SSHConfig()
-    config_path = os.path.expanduser("~/.ssh/config")
-    if os.path.exists(config_path):
-        with open(config_path) as f:
-            ssh_config.parse(f)
-    cfg = ssh_config.lookup(host_alias)
 
-    # Extract connection parameters, falling back to defaults
-    hostname     = cfg.get("hostname", host_alias)
-    port         = int(cfg.get("port", 22))
-    username     = cfg.get("user", None)
-    identityfile = cfg.get("identityfile", None)  # can be a list
-    proxy_cmd    = cfg.get("proxycommand", None)
+    def __init__(self, host_alias: str):
+        self.host_alias = host_alias
+        self.client: paramiko.SSHClient | None = None
 
-    # Create a proxy socket if a ProxyCommand is specified
-    proxy_sock = ProxyCommand(proxy_cmd) if proxy_cmd else None
+    # ------------------------------------------------------------------
+    def __enter__(self):
+        """Establish the SSH connection using ``~/.ssh/config`` settings."""
+        ssh_config = SSHConfig()
+        config_path = os.path.expanduser("~/.ssh/config")
+        if os.path.exists(config_path):
+            with open(config_path) as f:
+                ssh_config.parse(f)
+        cfg = ssh_config.lookup(self.host_alias)
 
-    # Initialize and configure the SSH client
-    client = paramiko.SSHClient()
-    client.load_system_host_keys()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        hostname = cfg.get("hostname", self.host_alias)
+        port = int(cfg.get("port", 22))
+        username = cfg.get("user", None)
+        identityfile = cfg.get("identityfile", None)
+        proxy_cmd = cfg.get("proxycommand", None)
 
-    try:
-        # Establish the SSH connection with a 5-second timeout
-        client.connect(
-            hostname     = hostname,
-            port         = port,
-            username     = username,
-            key_filename = identityfile,
-            timeout      = 5,
-            allow_agent  = True,
-            look_for_keys= True,
-            sock         = proxy_sock,
+        proxy_sock = ProxyCommand(proxy_cmd) if proxy_cmd else None
+
+        self.client = paramiko.SSHClient()
+        self.client.load_system_host_keys()
+        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.client.connect(
+            hostname=hostname,
+            port=port,
+            username=username,
+            key_filename=identityfile,
+            timeout=5,
+            allow_agent=True,
+            look_for_keys=True,
+            sock=proxy_sock,
         )
+        return self
 
-        # Execute the command and collect output
-        _, stdout, stderr = client.exec_command(command)
+    # ------------------------------------------------------------------
+    def run(self, command: str) -> str:
+        """Execute a command on the active SSH session."""
+        if self.client is None:
+            raise RuntimeError("SSH session is not connected")
+        _, stdout, stderr = self.client.exec_command(command)
         out = stdout.read().decode()
         err = stderr.read().decode()
         return out + err
 
-    finally:
-        # Ensure the connection is always closed
-        client.close()
+    # ------------------------------------------------------------------
+    def __exit__(self, exc_type, exc, tb):
+        if self.client is not None:
+            self.client.close()
+            self.client = None
+
+def run_ssh_command(host_alias: str, command: str) -> str:
+    """Execute a single command on a remote host.
+
+    This is a convenience wrapper around :class:`SSHSession` for backwards
+    compatibility.  Each invocation opens a new session, runs the command, and
+    then closes the connection.
+    """
+    with SSHSession(host_alias) as session:
+        return session.run(command)


### PR DESCRIPTION
## Summary
- add `SSHSession` to reuse SSH connections for multiple commands
- allow `get_username_by_pid` to use existing session
- update `main` to run all GPU checks within a single SSH session per host

## Testing
- `pytest -q` *(fails: Name or service not known)*


------
https://chatgpt.com/codex/tasks/task_e_689320840a5483219395c7ecdddd38bb